### PR TITLE
 Use LOG_DIR from env

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -3,7 +3,8 @@ import winston, { format } from 'winston';
 
 import 'winston-daily-rotate-file';
 
-const LOG_DIR = 'logs';
+// Use LOG_DIR from env 
+const LOG_DIR = process.env.LOG_DIR || 'logs';
 const LOG_LEVEL = process.env.LOG_LEVEL || 'info';
 
 // Create log directory if it does not exist


### PR DESCRIPTION
LOG_DIR was hardcoded and was creating error while deploying to AWS Lambda.